### PR TITLE
Add geometry module to utils barrel export

### DIFF
--- a/src/ecs/systems/gameplay/CombatSystem.ts
+++ b/src/ecs/systems/gameplay/CombatSystem.ts
@@ -5,7 +5,7 @@ import type { GameSystem } from '@/ecs/GameSystem';
 import { gameEvents, GameEvents } from '@/events';
 import { Vector, SpatialGrid, getEntityType } from '@/utils';
 import { ENTITY_CONFIG } from '@/config';
-import { pointToSegmentDistance } from '@/utils/geometry';
+import { pointToSegmentDistance } from '@/utils';
 import { AttackHandlerRegistry } from './attacks/AttackHandlerRegistry';
 import type { AttackContext } from './attacks/AttackHandler';
 

--- a/src/ecs/systems/gameplay/InteractionSystem.ts
+++ b/src/ecs/systems/gameplay/InteractionSystem.ts
@@ -2,7 +2,7 @@ import type { Query, With } from 'miniplex';
 import type { Entity, GameWorld, Team } from '@/ecs/Entity';
 import type { GameSystem } from '@/ecs/GameSystem';
 import { Vector, SpatialGrid } from '@/utils';
-import { pointToSegmentDistance } from '@/utils/geometry';
+import { pointToSegmentDistance } from '@/utils';
 
 type InteractiveEntity = With<Entity, 'interaction' | 'position' | 'targeting'>;
 

--- a/src/ecs/systems/gameplay/WallActivationSystem.ts
+++ b/src/ecs/systems/gameplay/WallActivationSystem.ts
@@ -3,7 +3,7 @@ import type { Entity, GameWorld } from '@/ecs/Entity';
 import type { GameSystem } from '@/ecs/GameSystem';
 import { GAME_CONFIG } from '@/config';
 import { gameEvents, GameEvents } from '@/events';
-import { lineSegmentToRect, pointToSegmentDistance } from '@/utils/geometry';
+import { lineSegmentToRect, pointToSegmentDistance } from '@/utils';
 
 export class WallActivationSystem implements GameSystem {
   private world: GameWorld;

--- a/src/ecs/systems/gameplay/WallBreakingSystem.ts
+++ b/src/ecs/systems/gameplay/WallBreakingSystem.ts
@@ -3,7 +3,7 @@ import type { Entity, GameWorld } from '@/ecs/Entity';
 import type { GameSystem } from '@/ecs/GameSystem';
 import { GAME_CONFIG } from '@/config';
 import { gameEvents, GameEvents } from '@/events';
-import { pointToSegmentDistance } from '@/utils/geometry';
+import { pointToSegmentDistance } from '@/utils';
 
 export class WallBreakingSystem implements GameSystem {
   private wallAttackers: Query<With<Entity, 'wallAttackTarget' | 'position' | 'monsterTag'>>;

--- a/src/ecs/systems/gameplay/attacks/PulseAttackHandler.ts
+++ b/src/ecs/systems/gameplay/attacks/PulseAttackHandler.ts
@@ -2,7 +2,7 @@ import type { AttackHandler, AttackContext } from './AttackHandler';
 import { Vector } from '@/utils';
 import { gameEvents, GameEvents } from '@/events/GameEvents';
 import type { Entity } from '@/ecs/Entity';
-import { pointToSegmentDistance } from '@/utils/geometry';
+import { pointToSegmentDistance } from '@/utils';
 
 export class PulseAttackHandler implements AttackHandler {
   onCharging(context: AttackContext): void {

--- a/src/ecs/systems/ui/WallPlacementSystem.ts
+++ b/src/ecs/systems/ui/WallPlacementSystem.ts
@@ -5,7 +5,7 @@ import type { EnergyManager } from '@/ui/EnergyManager';
 import { GAME_CONFIG } from '@/config';
 import { gameEvents, GameEvents } from '@/events';
 import { createWallBlueprint } from '@/entities/factories';
-import { nearestPointOnPolyline, raySegmentIntersection } from '@/utils/geometry';
+import { nearestPointOnPolyline, raySegmentIntersection } from '@/utils';
 
 type WallPlacementState = 'idle' | 'selectingFirst' | 'selectingSecond';
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './vector';
 export * from './logger';
 export * from './SpatialGrid';
 export * from './entityType';
+export * from './geometry';


### PR DESCRIPTION
## Summary
- Added `export * from './geometry'` to `src/utils/index.ts`
- Updated 6 files to import geometry functions from `@/utils` instead of `@/utils/geometry`

## Files Changed
- `src/utils/index.ts` - Added geometry export to barrel
- `src/ecs/systems/ui/WallPlacementSystem.ts` - Updated imports (2 functions)
- `src/ecs/systems/gameplay/CombatSystem.ts` - Updated imports (1 function)
- `src/ecs/systems/gameplay/WallBreakingSystem.ts` - Updated imports (1 function)  
- `src/ecs/systems/gameplay/attacks/PulseAttackHandler.ts` - Updated imports (1 function)
- `src/ecs/systems/gameplay/InteractionSystem.ts` - Updated imports (1 function)
- `src/ecs/systems/gameplay/WallActivationSystem.ts` - Updated imports (2 functions)

## Impact
Makes geometry imports consistent with other utils modules. All geometry functions (`pointToSegmentDistance`, `nearestPointOnPolyline`, `raySegmentIntersection`, `lineSegmentToRect`) are now available through the barrel export.

## Testing
- ✅ TypeScript compilation passes (pre-existing type errors in unrelated files)
- ✅ Test suite passes (1480/1484 tests pass, 4 failures are pre-existing in worktree)
- ✅ No naming collisions detected
- ✅ Zero remaining imports from \`@/utils/geometry\`

Closes #5